### PR TITLE
添加 gitalk 评论插件；使用 fancybox 实现点击图片放大；修改部分样式

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -7,7 +7,7 @@ A brand new default theme for [[Hexo](https://hexo.io)].  [Preview](http://cofes
 ## 特色
 
 - 多语言
-- 第三方评论框（友言、来必力、gitment）
+- 第三方评论框（友言、来必力、gitment、gitalk）
 - 可展示个人豆瓣书单
 - 可展示个人github托管项目
 - 可设置支付宝、微信打赏
@@ -164,7 +164,7 @@ share:
 
 ### 评论
 
-主题集成了[disqus](https://disqus.com/)、[友言](http://www.uyan.cc/)、[来必力](https://livere.com/)、[gitment](https://github.com/imsun/gitment)评论系统，选择其中一种即可
+主题集成了[disqus](https://disqus.com/)、[友言](http://www.uyan.cc/)、[来必力](https://livere.com/)、[gitment](https://github.com/imsun/gitment)、[gitalk](https://github.com/gitalk/gitalk)评论系统，选择其中一种即可
 
 ```
 # Comment

--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,9 @@ index_widgets:
 archive_type: 'monthly'
 show_count: true
 
+# Fancybox support
+fancybox: true
+
 # Search
 search:
   insight: true # you need to install `hexo-generator-json-content` before using Insight Search
@@ -106,7 +109,7 @@ github:
 # Gitment
 # Introduction: https://imsun.net/posts/gitment-introduction/
 comment:
-  type: valine  # 启用哪种评论系统
+  type: gitalk  # 启用哪种评论系统
   disqus:  # enter disqus shortname here
   youyan: 
     uid: 1783844 # enter youyan uid 
@@ -118,6 +121,12 @@ comment:
     ClientID: 
     ClientSecret: 
     lazy: false
+  gitalk: # gitalk. https://gitalk.github.io/
+    owner:  #必须. GitHub repository 所有者，可以是个人或者组织。
+    admin:  #必须. GitHub repository 的所有者和合作者 (对这个 repository 有写权限的用户)。
+    repo:  #必须. GitHub repository.
+    ClientID: #必须. GitHub Application Client ID.
+    ClientSecret: #必须. GitHub Application Client Secret.
   valine: # Valine. https://valine.js.org
     appid:  # your leancloud application appid
     appkey:  # your leancloud application appkey

--- a/layout/_common/script.ejs
+++ b/layout/_common/script.ejs
@@ -1,6 +1,39 @@
-<script src="https://cdn.bootcss.com/jquery/1.12.4/jquery.min.js"></script>
+<!-- <script src="https://cdn.bootcss.com/jquery/1.12.4/jquery.min.js"></script> -->
+<script src="https://cdn.bootcss.com/jquery/3.3.1/jquery.min.js"></script>
+
 <script>
-window.jQuery || document.write('<script src="js/jquery.min.js"><\/script>')
+    window.jQuery || document.write('<script src="js/jquery.min.js"><\/script>')
 </script>
+<% if (theme.fancybox) { %>
+    <link href="https://cdn.bootcss.com/fancybox/3.3.5/jquery.fancybox.min.css" rel="stylesheet">
+    <script src="https://cdn.bootcss.com/fancybox/3.3.5/jquery.fancybox.min.js"></script>
+    <script>
+        //利用 FancyBox 实现点击图片放大
+        $(document).ready(function() {
+            $('article img').not('[hidden]').not('.panel-body img').each(function () {
+                var $image = $(this);
+                var imageCaption = $image.attr('alt');
+                var $imageWrapLink = $image.parent('a');
+                if ($imageWrapLink.length < 1) {
+                var src = this.getAttribute('src');
+                var idx = src.lastIndexOf('?');
+                if (idx != -1) {
+                    src = src.substring(0, idx);
+                }
+                $imageWrapLink = $image.wrap('<a href="' + src + '"></a>').parent('a');
+                }
+                $imageWrapLink.attr('data-fancybox', 'images');
+                if (imageCaption) {
+                $imageWrapLink.attr('data-caption', imageCaption);
+                }
+            });
+            $().fancybox({
+                selector: '[data-fancybox="images"]',
+                hash: false,
+                loop: false,
+            }); 
+        });
+    </script>
+    <% } %>
 <%- js('js/plugin.min') %>
 <%- js('js/application') %>

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -14,7 +14,7 @@
         <%- partial('post/wordcount') %>
       </div>
     </div>
-    <div class="article-entry markdown-body" itemprop="articleBody">
+    <div class="article-entry marked-body" itemprop="articleBody">
       <% if (post.excerpt && index){ %>
         <%- post.excerpt %>
         <% if (theme.config.excerpt_link){ %>

--- a/layout/_partial/post/comment.ejs
+++ b/layout/_partial/post/comment.ejs
@@ -10,6 +10,8 @@
        <%- partial('_script/_comment/gitment') %>    
     <% } else if (theme.comment.type === 'valine') { %>
        <%- partial('_script/_comment/valine') %>    
-    <% } %>
+    <% }  else if (theme.comment.type === 'gitalk') { %>
+      <%- partial('_script/_comment/gitalk') %>    
+   <% } %>
   </section>
 <% } %>

--- a/layout/_script/_comment/gitalk.ejs
+++ b/layout/_script/_comment/gitalk.ejs
@@ -1,0 +1,18 @@
+<% if (typeof(script) !== 'undefined' && script) { %>
+    <link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
+    <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
+    <script type="text/javascript">
+        var gitalk = new Gitalk({
+            clientID: '<%= theme.comment.gitalk.ClientID %>',
+            clientSecret: '<%= theme.comment.gitalk.ClientSecret %>',
+            repo: '<%= theme.comment.gitalk.repo %>',
+            owner: '<%= theme.comment.gitalk.owner %>',
+            admin: ['<%= theme.comment.gitalk.admin %>'],
+            id: location.pathname,
+            distractionFreeMode: true
+        })
+        gitalk.render('comments')
+    </script>
+<% } else { %>
+
+<% } %>

--- a/layout/_script/_comment/script.ejs
+++ b/layout/_script/_comment/script.ejs
@@ -8,4 +8,6 @@
     <%- partial('_script/_comment/gitment', { script: true }) %>   
 <% } else if (theme.comment.type === 'valine') { %>
     <%- partial('_script/_comment/valine', { script: true }) %>    
+<% } else if (theme.comment.type === 'gitalk') { %>
+    <%- partial('_script/_comment/gitalk', { script: true }) %>    
 <% } %>

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -484,7 +484,7 @@ h6,
 }
 
 p {
-  margin: 0 0 10px;
+  margin: 0 0 10px 0;
 }
 
 .lead {
@@ -5940,6 +5940,13 @@ body.no-sidebar .sidebar {
   margin-bottom: 70px;
 }
 
+.main img{
+  box-sizing: border-box;
+  margin: auto;
+  padding: 3px;
+  border: 1px solid #ddd;
+}
+
 #comments .gitment-footer-container,
 #comments .gitment-footer-project-link {
   display: none !important;
@@ -6082,6 +6089,16 @@ body.no-sidebar .sidebar {
 
 .tagcloud a {
   display: inline-block;
+  line-height: 20px;
+  height: 20px;
+  margin: 3px;
+  padding: 0 3px;
+  color: #555;
+  border-radius: 3px;
+  background: #eee;
+  min-width: 30px;
+  font-size: 12px;
+  text-align: center;
 }
 
 .bar .pager .next > a,
@@ -6456,43 +6473,43 @@ body.no-sidebar .sidebar {
   padding: 14px 0;
 }
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
+.marked-body h1,
+.marked-body h2,
+.marked-body h3,
+.marked-body h4,
+.marked-body h5,
+.marked-body h6 {
   margin-top: 24px;
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
 }
 
-.markdown-body h1 {
+.marked-body h1 {
   padding-bottom: 0.3em;
   font-size: 2em;
   border-bottom: 1px solid #f2f2f2;
 }
 
-.markdown-body h2 {
+.marked-body h2 {
   padding-bottom: 0.3em;
   font-size: 1.5em;
   border-bottom: 1px solid #f2f2f2;
 }
 
-.markdown-body a {
+.marked-body a {
   color: #2196f3;
   text-decoration: none;
 }
 
-.markdown-body a:focus,
-.markdown-body a:hover {
+.marked-body a:focus,
+.marked-body a:hover {
   color: #0a6ebd;
   text-decoration: none;
 }
 
-.markdown-body ul,
-.markdown-body ol {
+.marked-body ul,
+.marked-body ol {
   padding-left: 0;
   margin-left: 20px;
 }
@@ -8164,8 +8181,8 @@ body.okayNav-loaded {
     left: -25px;
   }
 
-  .markdown-body .headerlink:before,
-  .markdown-body .markdownIt-Anchor:before {
+  .marked-body .headerlink:before,
+  .marked-body .markdownIt-Anchor:before {
     display: inline-block;
     width: 18px;
     content: "#";
@@ -8175,27 +8192,27 @@ body.okayNav-loaded {
     visibility: hidden;
   }
 
-  .markdown-body .headerlink:before {
+  .marked-body .headerlink:before {
     margin-left: -15px;
     padding-right: 2px;
   }
 
-  .markdown-body .markdownIt-Anchor:before {
+  .marked-body .markdownIt-Anchor:before {
     margin-left: -20px;
   }
 
-  .markdown-body h1:hover .headerlink:before,
-  .markdown-body h1:hover .markdownIt-Anchor:before,
-  .markdown-body h2:hover .headerlink:before,
-  .markdown-body h2:hover .markdownIt-Anchor:before,
-  .markdown-body h3:hover .headerlink:before,
-  .markdown-body h3:hover .markdownIt-Anchor:before,
-  .markdown-body h4:hover .headerlink:before,
-  .markdown-body h4:hover .markdownIt-Anchor:before,
-  .markdown-body h5:hover .headerlink:before,
-  .markdown-body h5:hover .markdownIt-Anchor:before,
-  .markdown-body h6:hover .headerlink:before,
-  .markdown-body h6:hover .markdownIt-Anchor:before {
+  .marked-body h1:hover .headerlink:before,
+  .marked-body h1:hover .markdownIt-Anchor:before,
+  .marked-body h2:hover .headerlink:before,
+  .marked-body h2:hover .markdownIt-Anchor:before,
+  .marked-body h3:hover .headerlink:before,
+  .marked-body h3:hover .markdownIt-Anchor:before,
+  .marked-body h4:hover .headerlink:before,
+  .marked-body h4:hover .markdownIt-Anchor:before,
+  .marked-body h5:hover .headerlink:before,
+  .marked-body h5:hover .markdownIt-Anchor:before,
+  .marked-body h6:hover .headerlink:before,
+  .marked-body h6:hover .markdownIt-Anchor:before {
     visibility: visible;
   }
 }


### PR DESCRIPTION
*这是一款非常漂亮的Hexo主题，感谢作者*

本次 PR 内容有： 
1. 添加 [Gitalk](https://github.com/gitalk/gitalk/) 评论
2. 使用 [fancybox](https://github.com/fancyapps/fancybox) 实现点击图片放大
3. 修改标签云显示样式，文章图片显示样式，同时由于 gitalk 的样式与主题有冲突，修改了样式表中的`markdown-body`为`marked-body`

-------------------------------------------------------------------------
在此基础上我还做了以下修改，但是不包括在本次 PR 中

4. 修改文章显示的字体行间距，颜色以及代码字体
5. 进入文章后自动展开 TOC

具体效果可以见我的博客：https://dmego.me