### PR TITLE
修改标签和分类因root不是 '/' 而出现问题

### DIFF
--- a/layout/categories.ejs
+++ b/layout/categories.ejs
@@ -5,9 +5,9 @@
       <p class="text-muted hidden-xs"><%= _p('total.category', site.categories.length) %></p>
       <nav role="navigation" id="nav-main" class="okayNav">
         <ul>
-          <li><a href="/categories"><%= __('nav.all') %></a></li>
+          <li><a href="<%= config.root %>categories"><%= __('nav.all') %></a></li>
           <% site.categories.each(function(item){ %>
-          <li><a href="/<%= item.path %>"><%= item.name %></a></li>
+          <li><a href="<%= config.root %><%= item.path %>"><%= item.name %></a></li>
           <% }) %>
         </ul>
       </nav>

--- a/layout/category.ejs
+++ b/layout/category.ejs
@@ -5,9 +5,9 @@
       <p class="hidden-xs"><%= _p('total.article', page.posts.length) %></p>
       <nav role="navigation" id="nav-main" class="okayNav">
         <ul>
-          <li><a href="/categories"><%= __('nav.all') %></a></li>
+          <li><a href="<%= config.root %>categories"><%= __('nav.all') %></a></li>
           <% site.categories.each(function(item){ %>
-          <li><a href="/<%= item.path %>"><%= item.name %></a></li>
+          <li><a href="<%= config.root %><%= item.path %>"><%= item.name %></a></li>
           <% }) %>
         </ul>
       </nav>

--- a/layout/tag.ejs
+++ b/layout/tag.ejs
@@ -5,9 +5,9 @@
       <p class="text-muted hidden-xs"><%= _p('total.article', page.posts.length) %></p>
       <nav role="navigation" id="nav-main" class="okayNav">
         <ul>
-          <li><a href="/tags"><%= __('nav.all') %></a></li>
+          <li><a href="<%= config.root %>tags"><%= __('nav.all') %></a></li>
           <% site.tags.each(function(item){ %>
-          <li><a href="/<%= item.path %>"><%= item.name %></a></li>
+          <li><a href="<%= config.root %><%= item.path %>"><%= item.name %></a></li>
           <% }) %>
         </ul>
       </nav>

--- a/layout/tags.ejs
+++ b/layout/tags.ejs
@@ -5,9 +5,9 @@
       <p class="text-muted hidden-xs"><%= _p('total.tag', site.tags.length) %></p>
       <nav role="navigation" id="nav-main" class="okayNav">
         <ul>
-          <li><a href="/tags"><%= __('nav.all') %></a></li>
+          <li><a href="<%= config.root %>tags"><%= __('nav.all') %></a></li>
           <% site.tags.each(function(item){ %>
-          <li><a href="/<%= item.path %>"><%= item.name %></a></li>
+          <li><a href="<%= config.root %><%= item.path %>"><%= item.name %></a></li>
           <% }) %>
         </ul>
       </nav>


### PR DESCRIPTION
主题不错，下载使用发现一个小BUG。我发现如果主配置的root不是 "/" 导致分类和标签页面渲染的路径有问题，就是如果你的root假设为 'my_blog'，分类下的各个分类渲染的路径不是从 'my_blog' 开始的，我加了一个`<%= config.root %>`在标签和分类的代码里面，这样root设置为 '/' ，渲染为 /categories，root设置为my_blog，渲染为 /my_blog/categories。

不知道理解的对不对，大佬看看，可以的话就把修改提上去。