### PR TITLE
sort repo by star number and update time

### DIFF
--- a/layout/_script/repository.ejs
+++ b/layout/_script/repository.ejs
@@ -16,12 +16,21 @@ var open = function() {
         errorContainer.remove();
         countContainer.text(result.length); //设置项目个数
         var ul = $("<ul class='repo-list row clearfix'></ul>");
-        for (var i in result) {
-          var repo = result[i];
+        result.sort(function(a, b) {
+          return new Date(b.updated_at) - new Date(a.updated_at)
+        }).sort(function(a, b) {
+          var a_start = a.stargazers_count;
+          var b_start = b.stargazers_count;
+          if (a.fork) a_start * 0.5;
+          if (b.fork) b_start * 0.5;
+          return b_start - a_start;
+        }).map(function(repo) {
+          if (!repo.description) repo.description = "";
           repo.updated_at = repo.updated_at.substring(0, repo.updated_at.lastIndexOf("T"));
           var html = baiduTpl.list(repo);
           ul.append(html);
-        }
+        })
+
         repoContainer.append(ul);
         $(".geopattern").each(function() {
           $(this).geopattern($(this).data('pattern-id'));


### PR DESCRIPTION
对 GitHub 项目的用更新时间和start数排序。使重要的或者活跃的项目排在前面。

现在的方式是先按更新时间排序 再用 start数 （fork项目 *0.5）排序