### PR TITLE
link in about page can be not link and unclickable

### DIFF
--- a/layout/_partial/sidebar-about.ejs
+++ b/layout/_partial/sidebar-about.ejs
@@ -8,7 +8,11 @@
           <% for(var i in theme.profile.links) { %>
           <li>
             <%= i %>:
-            <a href="<%- theme.profile.links[i] %>" target="_blank"><%- theme.profile.links[i] %></a>
+            <% if (theme.profile.links[i].startsWith('http')) { %>
+              <a href="<%- theme.profile.links[i] %>" target="_blank"><%- theme.profile.links[i] %></a>
+            <%  } else { %>
+              <a><%- theme.profile.links[i] %></a>
+            <% } %>
           </li>
           <% } %>
         </ul>


### PR DESCRIPTION
通过判断links是否是http协议的网址，来决定是否渲染 `href `

这样关于界面的 links 可以放不是网址的东西（例如#替换的邮箱， 微信号等），而不会被导向不存在的页面。