### PR TITLE
change: default open toc when theme,config.toc is true, but can disab…

### DIFF
--- a/layout/_partial/post/nav.ejs
+++ b/layout/_partial/post/nav.ejs
@@ -12,7 +12,7 @@
       <a href="<%- url_for(post.next.path) %>" title="<%= post.next.title || '(no title)' %>"><span><%= __('nav.older') %>&nbsp;&nbsp;</span><i class="icon icon-angle-right" aria-hidden="true"></i></a>
     </li>
     <% } %>
-    <% if (!index && theme.config.toc && post.toc) { %>
+    <% if (!index && theme.config.toc && (post.toc !== false)) { %>
     <li class="toggle-toc">
       <a class="toggle-btn collapsed" data-toggle="collapse" href="#collapseToc" aria-expanded="false" title="<%= __('article.catalogue') %>" role="button">
         <span>[&nbsp;</span><span><%= __('article.catalogue') %></span>

--- a/layout/_partial/sidebar-toc.ejs
+++ b/layout/_partial/sidebar-toc.ejs
@@ -1,4 +1,4 @@
-<% if (!index && theme.config.toc && post.toc) { %>
+<% if (!index && theme.config.toc && (post.toc !== false)) { %>
 <aside class="sidebar sidebar-toc collapse" id="collapseToc" itemscope itemtype="http://schema.org/WPSideBar">
   <div class="slimContent">
     <nav id="toc" class="article-toc">


### PR DESCRIPTION
更改之前 toc 要在 theme.config.toc 和 front-matter 中 toc 域同时设置为 true 才会开启。 这样我觉得有点不太对劲。

更改之后在 theme.config.toc 为 true 则默认开启 toc， 但是可以通过具体文章的 front-matter 设置成 false 关闭。

我觉得这样更符合逻辑一些。默认开启 toc 应该不会有什么消耗吧。毕竟是 Hexo 生成好的