### PR TITLE
fixbug: add douban api request parameter apikey

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -152,6 +152,7 @@ douban:
   user: # 豆瓣用户名
   start: 0 # 从哪一条记录开始
   count: 100 # 获取豆瓣书单数据条数
+  apikey: # 豆瓣apikey
   
 # PV
 pv:

--- a/layout/_script/douban.ejs
+++ b/layout/_script/douban.ejs
@@ -56,7 +56,8 @@ function show(id) {
       type: 'GET',
       data: {
         start:<%= theme.douban.start %>, // 从哪一条记录开始
-        count:<%= theme.douban.count %> // 获取豆瓣书单数据条数
+        count:<%= theme.douban.count %>, // 获取豆瓣书单数据条数
+        apikey:'<%= theme.douban.apikey %>' // 豆瓣apikey
       },
       dataType: 'JSONP', //here
       success: function(data) {


### PR DESCRIPTION
豆瓣下线了之前的公开API，所有请求都会报 msg: "invalid_apikey"，
修改内容：在请求时填加了一个apikey参数